### PR TITLE
fix get_many output format

### DIFF
--- a/AerospikeClientMock/AerospikeClientMock.py
+++ b/AerospikeClientMock/AerospikeClientMock.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 #  aerospike mockserver
+import copy
 import hashlib
 
 from .AerospikeData import AerospikeData
@@ -25,8 +26,8 @@ class AerospikeClientMock(object):
 
     def get(self, key, policy=None):
         exists = self.exists(key)[0]
-        return key, self.storage[key].meta if exists else None, \
-               self.storage[key] if exists else None
+        data = copy.deepcopy(self.storage[key]) if exists else None
+        return key, data.meta if exists else None, data if exists else None
 
     def select(self, key, bins, policy=None):
         result = self.get(key)
@@ -114,7 +115,8 @@ class AerospikeClientMock(object):
         result = []
         for key in keys:
             _, meta, data = self.get(key)
-            digest = bytearray(hashlib.md5('#'.join([str(x) for x in key])).digest())
+            joined = b'#'.join([str(x).encode('utf-8') for x in key])
+            digest = bytearray(hashlib.md5(joined).digest())
             key = tuple(list(key) + [digest])
             result.append((key, meta, data))
         return result

--- a/AerospikeClientMock/AerospikeClientMock.py
+++ b/AerospikeClientMock/AerospikeClientMock.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 #  aerospike mockserver
-
+import hashlib
 
 from .AerospikeData import AerospikeData
 from .AerospikeQueryMock import AerospikeQueryMock
@@ -113,7 +113,10 @@ class AerospikeClientMock(object):
     def get_many(self, keys, policy=None):
         result = []
         for key in keys:
-            result.append(self.get(key))
+            _, meta, data = self.get(key)
+            digest = bytearray(hashlib.md5('#'.join([str(x) for x in key])).digest())
+            key = tuple(list(key) + [digest])
+            result.append((key, meta, data))
         return result
 
     def exists_many(self, keys, policy=None):

--- a/tests/test_AerospikeClientMock.py
+++ b/tests/test_AerospikeClientMock.py
@@ -166,11 +166,11 @@ class TestAerospikeClientMock(unittest.TestCase):
         ]
         self.assertEqual(
             [
-                (('a', 'b', 1), {'gen': 1, 'ttl': 0}, {'a': 1}),
-                (('a', 'b', 2), {'gen': 1, 'ttl': 0}, {'a': 2}),
-                (('a', 'b', 3), {'gen': 1, 'ttl': 0}, {'a': 3}),
-                (('a', 'b', 4), {'gen': 1, 'ttl': 0}, {'a': 4}),
-                (('a', 'b', 5), None, None),
+                (('a', 'b', 1, bytearray(b'u\x98t\x11La\x84\x9d\x94\xe3\xcdcSbn\xd7')), {'gen': 1, 'ttl': 0}, {'a': 1}),
+                (('a', 'b', 2, bytearray(b'\xe7HY\x1f\x1f\xb8z\x8f\xf3\x0c\xf3\x04\xcc9\x14\xdc')), {'gen': 1, 'ttl': 0}, {'a': 2}),
+                (('a', 'b', 3, bytearray(b'\xeb\x1a\x99(V\xd49\x01\xeeQ[\x92\x06-O\x08')), {'gen': 1, 'ttl': 0}, {'a': 3}),
+                (('a', 'b', 4, bytearray(b'\xf3G\x1b\xba\xe2\xec\x11S\xc3\xc2\xab\x15\xb4\x1b\x96q')), {'gen': 1, 'ttl': 0}, {'a': 4}),
+                (('a', 'b', 5, bytearray(b'd\t}\xc6`\xee\xe2\xf0)\x1f7\x9c\xfa\x8d\xa6\xd6')), None, None),
             ]
             , asm.get_many(keys))
 

--- a/tests/test_AerospikeClientTtlMock.py
+++ b/tests/test_AerospikeClientTtlMock.py
@@ -215,26 +215,26 @@ class TestAerospikeClientTtlMock(unittest.TestCase):
         self.assertEqual(
             [
                 (
-                    ('a', 'b', 1),
+                    ('a', 'b', 1, bytearray(b'u\x98t\x11La\x84\x9d\x94\xe3\xcdcSbn\xd7')),
                     {'gen': 1, 'ttl': self.get_time(default_ttl)},
                     {'a': 1}
                 ),
                 (
-                    ('a', 'b', 2),
+                    ('a', 'b', 2, bytearray(b'\xe7HY\x1f\x1f\xb8z\x8f\xf3\x0c\xf3\x04\xcc9\x14\xdc')),
                     {'gen': 1, 'ttl': self.get_time(default_ttl)},
                     {'a': 2}
                 ), (
-                ('a', 'b', 3),
+                ('a', 'b', 3, bytearray(b'\xeb\x1a\x99(V\xd49\x01\xeeQ[\x92\x06-O\x08')),
                 {'gen': 1, 'ttl': self.get_time(default_ttl)},
                 {'a': 3}
             ),
                 (
-                    ('a', 'b', 4),
+                    ('a', 'b', 4, bytearray(b'\xf3G\x1b\xba\xe2\xec\x11S\xc3\xc2\xab\x15\xb4\x1b\x96q')),
                     {'gen': 1, 'ttl': self.get_time(default_ttl)},
                     {'a': 4}
                 ),
                 (
-                    ('a', 'b', 5),
+                    ('a', 'b', 5, bytearray(b'd\t}\xc6`\xee\xe2\xf0)\x1f7\x9c\xfa\x8d\xa6\xd6')),
                     None,
                     None
                 ),


### PR DESCRIPTION
according to [client description](https://www.aerospike.com/apidocs/python/client.html#aerospike.Client.get_many) get_many injects digest to the key